### PR TITLE
Removing site.ini file

### DIFF
--- a/settings/site.ini
+++ b/settings/site.ini
@@ -1,6 +1,0 @@
-<?php /* #?ini charset="utf-8"?
-
-[TemplateSettings]
-ExtensionAutoloadPath[]=mugoobjectrelations
-
-*/ ?>


### PR DESCRIPTION
That extension claims to have template operators but it does not have it. So we can remove the extension site.ini file