### PR TITLE
Replacing PHP function each with foreach

### DIFF
--- a/datatypes/mugoobjectrelationlist/mugoobjectrelationlisttype.php
+++ b/datatypes/mugoobjectrelationlist/mugoobjectrelationlisttype.php
@@ -265,13 +265,13 @@ class MugoObjectRelationListType extends eZDataType
         $content['relation_list'] = array();
         reset( $reorderedRelationList );
         $i = 0;
-        while ( list( $key, $relationItem ) = each( $reorderedRelationList ) )
+        foreach($reorderedRelationList as $key => $relationItem)
         {
             $content['relation_list'][] = $relationItem;
             $content['relation_list'][$i]['priority'] = $i + 1;
             ++$i;
         }
-        
+
         // Store extra fields (attribute-level) fields
         $extraFieldsBase = $base . '_extra_fields_attribute_level_' . $contentObjectAttributeID;
         $extraFieldList = array();


### PR DESCRIPTION
PHP function each is not available in higher PHP versions. I replaced that code with the PHP function foreach.